### PR TITLE
Dev

### DIFF
--- a/src/CodeBlocks.Core.Web/CodeBlocks.Web.csproj
+++ b/src/CodeBlocks.Core.Web/CodeBlocks.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>0.1.20-beta</Version>
+    <Version>0.1.25-beta</Version>
     <Authors>WIG</Authors>
     <PackageId>codeblocks.web</PackageId>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/src/CodeBlocks.Core.Web/Extensions/ObjectExtensions.cs
+++ b/src/CodeBlocks.Core.Web/Extensions/ObjectExtensions.cs
@@ -49,6 +49,11 @@ namespace CodeBlocks.Web.Extensions
 
 
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="property"></param>
+        /// <returns></returns>
         private static string GetQueryStringParameterName(PropertyInfo property)
         {
             var attrs = property.GetCustomAttributes();
@@ -56,6 +61,9 @@ namespace CodeBlocks.Web.Extensions
             {
                 if (attr is QueryStringParameterAttribute authAttr)
                 {
+                    if (string.IsNullOrWhiteSpace(authAttr.Name))
+                        return property.Name;
+
                     return authAttr.Name;
                 }
             }

--- a/src/CodeBlocks.Core.Web/Http/Extensions/HttpClient.cs
+++ b/src/CodeBlocks.Core.Web/Http/Extensions/HttpClient.cs
@@ -17,15 +17,15 @@ namespace CodeBlocks.Web.Http.Extensions
         /// <typeparam name="TResponse">Type of the response.</typeparam>
         /// <param name="httpClient">HttpClient</param>
         /// <param name="url">Url for the request.</param>
-        /// <param name="throwOnError">If true, the method will throw an Exception when the StatusCode of the response wasn't in 200-299 range.</param>
+        /// <param name="throwOnNotSuccessfull">If true, the method will throw an Exception when the StatusCode of the response wasn't in 200-299 range.</param>
         /// <returns></returns>
-        public static async Task<TResponse> GetJsonAsync<TResponse>(this HttpClient httpClient, string url, bool throwOnError = false)
+        public static async Task<TResponse> GetJsonAsync<TResponse>(this HttpClient httpClient, string url, bool throwOnNotSuccessfull = false)
         {
             var response = await httpClient.GetAsync(url);
 
             if (!response.IsSuccessStatusCode)
             {
-                if (throwOnError)
+                if (throwOnNotSuccessfull)
                 {
                     if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
                     {

--- a/src/CodeBlocks.Core.Web/Operations/OperationResultOfT.cs
+++ b/src/CodeBlocks.Core.Web/Operations/OperationResultOfT.cs
@@ -22,7 +22,7 @@ namespace CodeBlocks.Web.Operations
                     return Messages?.FirstOrDefault(m => m.Type == ResultMessageType.Error)?.Content;
                 }
 
-                if (Status == ResultStatus.Error)
+                if (Status == ResultStatus.Error || Status == ResultStatus.NotFound || Status == ResultStatus.Unauthorized)
                 {
                     return Messages?.FirstOrDefault(m => m.Type == ResultMessageType.Error)?.Content;
                 }
@@ -55,10 +55,23 @@ namespace CodeBlocks.Web.Operations
         {
             return new OperationResult<T>(value);
         }
+
+        public static OperationResult<T> Ok(T value, params string[] messages)
+        {
+            var resultMessages = messages.Select(error => new ResultMessage
+            {
+                Content = error,
+                Type = ResultMessageType.Success
+            }).ToList();
+
+            return new OperationResult<T>(ResultStatus.Ok, value, resultMessages);
+        }
+
         public static OperationResult<T> Error(List<ResultMessage> errors = null)
         {
             return new OperationResult<T>(ResultStatus.Error, default, errors);
         }
+
         public static OperationResult<T> Error(params string[] errors)
         {
             var resultMessages = errors.Select(error => new ResultMessage
@@ -69,14 +82,39 @@ namespace CodeBlocks.Web.Operations
 
             return new OperationResult<T>(ResultStatus.Error, default, resultMessages);
         }
+
         public static OperationResult<T> NotFound()
         {
             return new OperationResult<T>(ResultStatus.NotFound);
         }
+
+        public static OperationResult<T> NotFound(params string[] errors)
+        {
+            var resultMessages = errors.Select(error => new ResultMessage
+            {
+                Content = error,
+                Type = ResultMessageType.Error
+            }).ToList();
+
+            return new OperationResult<T>(ResultStatus.NotFound, default, resultMessages);
+        }
+
         public static OperationResult<T> Unauthorized()
         {
             return new OperationResult<T>(ResultStatus.Unauthorized);
         }
+
+        public static OperationResult<T> Unauthorized(params string[] errors)
+        {
+            var resultMessages = errors.Select(error => new ResultMessage
+            {
+                Content = error,
+                Type = ResultMessageType.Error
+            }).ToList();
+
+            return new OperationResult<T>(ResultStatus.Unauthorized, default, resultMessages);
+        }
+
         public static OperationResult<T> Invalid(List<ValidationError> validationErrors = null)
         {
             return new OperationResult<T>(ResultStatus.Invalid, default, null, validationErrors);

--- a/src/CodeBlocks.Core/CodeBlocks.Core.csproj
+++ b/src/CodeBlocks.Core/CodeBlocks.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>0.1.20-beta</Version>
+    <Version>0.1.25-beta</Version>
     <Authors>WIG</Authors>
     <PackageId>codeblocks.core</PackageId>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/src/CodeBlocks.Core/Model/Result.cs
+++ b/src/CodeBlocks.Core/Model/Result.cs
@@ -51,27 +51,27 @@ namespace CodeBlocks.Core.Model
 
 
 
-        protected virtual void AddMessage(ResultMessage message)
+        public virtual void AddMessage(ResultMessage message)
         {
             Messages.Add(message);
         }
 
-        protected virtual void AddErrorMessage(string message, string code = null)
+        public virtual void AddErrorMessage(string message, string code = null)
         {
             Messages.Add(ResultMessage.Error(message, code));
         }
 
-        protected virtual void AddSuccessMessage(string message, string code = null)
+        public virtual void AddSuccessMessage(string message, string code = null)
         {
             Messages.Add(ResultMessage.Success(message, code));
         }
 
-        protected virtual void AddWarningMessage(string message, string code = null)
+        public virtual void AddWarningMessage(string message, string code = null)
         {
             Messages.Add(ResultMessage.Error(message, code));
         }
 
-        protected virtual void AddInformationMessage(string message, string code = null)
+        public virtual void AddInformationMessage(string message, string code = null)
         {
             Messages.Add(ResultMessage.Information(message, code));
         }

--- a/tests/CodeBlocks.Web.Tests/Http/HttpExtensionsTests.cs
+++ b/tests/CodeBlocks.Web.Tests/Http/HttpExtensionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using CodeBlocks.Web.Http.Extensions;
+using System;
 using System.Net.Http;
 using Xunit;
 
@@ -15,11 +16,98 @@ namespace CodeBlocks.Web.Tests.Http
 
 
         [Theory]
+        [InlineData("https://_unexistent_/api/users/2")]
+        public async void GetJsonAsync_Request_Error(string url)
+        {
+            await Assert.ThrowsAsync<HttpRequestException>(async () => await _httpClient.GetJsonAsync<object>(url, true));
+        }
+
+        [Theory]
         [InlineData("https://reqres.in/api/users/2")]
-        public async void GetJsonAsync(string url)
+        public async void GetJsonAsync_Response_Successfull(string url)
         {
             var result = await _httpClient.GetJsonAsync<object>(url, true);
+            Assert.NotNull(result);
+        }
 
+        [Theory]
+        [InlineData("https://httpstat.us/400")]
+        [InlineData("https://httpstat.us/404")]
+        public async void GetJsonAsync_Response_Not_Successfull_NotThrow(string url)
+        {
+            var result = await _httpClient.GetJsonAsync<object>(url);
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData("https://httpstat.us/400")]
+        [InlineData("https://httpstat.us/404")]
+        public async void GetJsonAsync_Response_Not_Successfull_Throw(string url)
+        {
+            await Assert.ThrowsAsync<Exception>(async () => await _httpClient.GetJsonAsync<object>(url, true));
+        }
+
+        [Theory]
+        [InlineData("https://httpstat.us/401")]
+        public async void GetJsonAsync_Response_Not_Successfull_Throw_Unauthorized(string url)
+        {
+            await Assert.ThrowsAsync<UnauthorizedAccessException>(async () => await _httpClient.GetJsonAsync<object>(url, true));
+        }
+
+
+
+
+
+
+        [Theory]
+        [InlineData("https://_unexistent_/api/users/2")]
+        public async void PostJsonAsync_Request_Error(string url)
+        {
+            await Assert.ThrowsAsync<HttpRequestException>(async () => await _httpClient.PostJsonAsync<object>(url, true));
+        }
+
+        [Theory]
+        [InlineData("https://reqres.in/api/users/2")]
+        public async void PostJsonAsync_Response_Successfull(string url)
+        {
+            var result = await _httpClient.PostJsonAsync<object>(url, null);
+            Assert.NotNull(result);
+        }
+
+        [Theory]
+        [InlineData("https://reqres.in/api/users/2")]
+        public async void PostJsonAsync_Response_Successfull_With_Data(string url)
+        {
+            var request = new
+            {
+                Foo = "bar"
+            };
+            var result = await _httpClient.PostJsonAsync<object>(url, request);
+            Assert.NotNull(result);
+        }
+
+        [Theory]
+        [InlineData("https://httpstat.us/400")]
+        [InlineData("https://httpstat.us/404")]
+        public async void PostJsonAsync_Response_Not_Successfull_NotThrow(string url)
+        {
+            var result = await _httpClient.PostJsonAsync<object>(url);
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData("https://httpstat.us/400")]
+        [InlineData("https://httpstat.us/404")]
+        public async void PostJsonAsync_Response_Not_Successfull_Throw(string url)
+        {
+            await Assert.ThrowsAsync<Exception>(async () => await _httpClient.PostJsonAsync<object>(url, null, true));
+        }
+
+        [Theory]
+        [InlineData("https://httpstat.us/401")]
+        public async void PostJsonAsync_Response_Not_Successfull_Throw_Unauthorized(string url)
+        {
+            await Assert.ThrowsAsync<UnauthorizedAccessException>(async () => await _httpClient.PostJsonAsync<object>(url, null, true));
         }
     }
 }

--- a/tests/CodeBlocks.Web.Tests/OperationResultTests.cs
+++ b/tests/CodeBlocks.Web.Tests/OperationResultTests.cs
@@ -26,6 +26,17 @@ namespace CodeBlocks.Web.Tests
             Assert.True(result4.Success);
             Assert.Equal(ResultStatus.Ok, result4.Status);
             Assert.Equal(1, result4.Value);
+
+            var result5 = OperationResult<int>.Ok(1);
+            Assert.True(result5.Success);
+            Assert.Equal(ResultStatus.Ok, result5.Status);
+            Assert.Equal(1, result5.Value);
+
+            var result6 = OperationResult<int>.Ok(1, "OK");
+            Assert.True(result6.Success);
+            Assert.Equal(ResultStatus.Ok, result6.Status);
+            Assert.Equal(1, result6.Value);
+            Assert.Equal("OK", result6.UserMessage);
         }
 
 
@@ -67,10 +78,22 @@ namespace CodeBlocks.Web.Tests
             Assert.False(result1.Success);
             Assert.Equal(ResultStatus.Error, result1.Status);
 
-            // Created with ctor
-            var result2 = new OperationResult<int>(ResultStatus.Error);
+            var result2 = OperationResult<int>.Error("Error1");
             Assert.False(result2.Success);
             Assert.Equal(ResultStatus.Error, result2.Status);
+            Assert.Equal(1, result2.Messages.Count);
+            Assert.Equal("Error1", result2.UserMessage);
+
+            var result3 = OperationResult<int>.Error("Error1", "Error2");
+            Assert.False(result3.Success);
+            Assert.Equal(ResultStatus.Error, result3.Status);
+            Assert.Equal(2, result3.Messages.Count);
+            Assert.Equal("Error1", result3.UserMessage);
+
+            // Created with ctor
+            var result10 = new OperationResult<int>(ResultStatus.Error);
+            Assert.False(result10.Success);
+            Assert.Equal(ResultStatus.Error, result10.Status);
         }
 
 
@@ -82,10 +105,22 @@ namespace CodeBlocks.Web.Tests
             Assert.False(result1.Success);
             Assert.Equal(ResultStatus.NotFound, result1.Status);
 
+            var result3 = OperationResult<int>.NotFound("Error1");
+            Assert.False(result3.Success);
+            Assert.Equal(ResultStatus.NotFound, result3.Status);
+            Assert.Equal(1, result3.Messages.Count);
+            Assert.Equal("Error1", result3.UserMessage);
+
+            var result4 = OperationResult<int>.NotFound("Error1", "Error2");
+            Assert.False(result4.Success);
+            Assert.Equal(ResultStatus.NotFound, result4.Status);
+            Assert.Equal(2, result4.Messages.Count);
+            Assert.Equal("Error1", result4.UserMessage);
+
             // Created with ctor
-            var result2 = new OperationResult<int>(ResultStatus.NotFound);
-            Assert.False(result2.Success);
-            Assert.Equal(ResultStatus.NotFound, result2.Status);
+            var result10 = new OperationResult<int>(ResultStatus.NotFound);
+            Assert.False(result10.Success);
+            Assert.Equal(ResultStatus.NotFound, result10.Status);
         }
 
         [Fact]
@@ -95,6 +130,18 @@ namespace CodeBlocks.Web.Tests
             var result1 = OperationResult<int>.Unauthorized();
             Assert.False(result1.Success);
             Assert.Equal(ResultStatus.Unauthorized, result1.Status);
+
+            var result3 = OperationResult<int>.Unauthorized("Error1");
+            Assert.False(result3.Success);
+            Assert.Equal(ResultStatus.Unauthorized, result3.Status);
+            Assert.Equal(1, result3.Messages.Count);
+            Assert.Equal("Error1", result3.UserMessage);
+
+            var result4 = OperationResult<int>.Unauthorized("Error1", "Error2");
+            Assert.False(result4.Success);
+            Assert.Equal(ResultStatus.Unauthorized, result4.Status);
+            Assert.Equal(2, result4.Messages.Count);
+            Assert.Equal("Error1", result4.UserMessage);
 
             // Created with ctor
             var result2 = new OperationResult<int>(ResultStatus.Unauthorized);

--- a/tests/CodeBlocks.Web.Tests/QueryStringParameterTests.cs
+++ b/tests/CodeBlocks.Web.Tests/QueryStringParameterTests.cs
@@ -1,0 +1,46 @@
+﻿using CodeBlocks.Web.Extensions;
+using Microsoft.AspNetCore.WebUtilities;
+using Xunit;
+
+namespace CodeBlocks.Web.Tests
+{
+    public class QueryStringParameterTests
+    {
+        public const string PropWithNameValue = "foo";
+        public const string PropWithoutNameValue = "bar";
+
+
+        [Fact]
+        public void QueryStringParameter_With_Name_Value()
+        {
+            var requestObject = new SampleObject()
+            {
+                PropWithName = PropWithNameValue,
+                PropWithoutName = PropWithoutNameValue
+            };
+
+            var queryString = requestObject.ToQueryString();
+            Assert.NotNull(queryString);
+
+            var data = QueryHelpers.ParseQuery(queryString);
+
+            Assert.Contains(SampleObject.NamedParameterValue, data.Keys);
+            Assert.Equal(PropWithNameValue, data[SampleObject.NamedParameterValue]);
+
+            Assert.Contains(nameof(SampleObject.PropWithoutName), data.Keys);
+            Assert.Equal(PropWithoutNameValue, data[nameof(SampleObject.PropWithoutName)]);
+        }
+    }
+
+
+    public class SampleObject
+    {
+        public const string NamedParameterValue = "Prop_With_Name";
+
+        [QueryStringParameter(Name = NamedParameterValue)]
+        public string PropWithName { get; set; }
+
+        [QueryStringParameter]
+        public string PropWithoutName { get; set; }
+    }
+}


### PR DESCRIPTION
- #34 | Makes AddMessage* methods of Result public;
- Updates QueryStringParameter to allow default value when Name property is not passed;
- Adds more OperationResult static builders, that facilitates the creation os rsults with context messages;
- Adds more tests;